### PR TITLE
fix: launch puppeteer with minimal settings

### DIFF
--- a/src/core/render-core.js
+++ b/src/core/render-core.js
@@ -15,7 +15,7 @@ async function render(_opts = {}) {
       height: 1200,
     },
     goto: {
-      waitUntil: 'networkidle2',
+      waitUntil: 'networkidle0',
     },
     output: 'pdf',
     pdf: {


### PR DESCRIPTION
trying idea taken from https://www.bannerbear.com/blog/ways-to-speed-up-puppeteer-screenshots/

SC: https://app.shortcut.com/joor/story/130882/s3-brand-unable-to-print-linesheets-with-ats-inventory-for-collections-with-lots-of-styles-up-to-800-900-styles